### PR TITLE
Oppgradere pakker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ val kafkaEmbeddedEnvVersion = ext.get("kafkaEmbeddedEnvVersion").toString()
 val kafkaVersion = ext.get("kafkaVersion").toString() // Alligned med version fra kafka-embedded-env
 val k9FormatVersion = "5.1.33"
 val fuelVersion = "2.3.1"
-val kotlinVersion = "1.5.21"
 
 plugins {
     kotlin("jvm") version "1.5.21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,22 +1,23 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val dusseldorfKtorVersion = "2.1.6.0-ef0acb6"
+val dusseldorfKtorVersion = "2.1.6.2-6ce5eaa"
 val ktorVersion = ext.get("ktorVersion").toString()
 val mainClass = "no.nav.omsorgspengermidlertidigalene.AppKt"
 val kafkaEmbeddedEnvVersion = ext.get("kafkaEmbeddedEnvVersion").toString()
 val kafkaVersion = ext.get("kafkaVersion").toString() // Alligned med version fra kafka-embedded-env
 val k9FormatVersion = "5.1.33"
 val fuelVersion = "2.3.1"
+val kotlinVersion = "1.5.21"
 
 plugins {
-    kotlin("jvm") version "1.5.20"
+    kotlin("jvm") version "1.5.21"
     id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 buildscript {
     // Henter ut diverse dependency versjoner, i.e. ktorVersion.
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/ef0acb6425e85073932e8d021e33849110f58159/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/6ce5eaa4666595bb6b550fca5ca8bbdc242961a0/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {
@@ -40,6 +41,7 @@ dependencies {
     // Test
     testImplementation("no.nav.helse:dusseldorf-test-support:$dusseldorfKtorVersion")
     testImplementation("no.nav:kafka-embedded-env:$kafkaEmbeddedEnvVersion")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion") {
         exclude(group = "org.eclipse.jetty")
     }
@@ -102,4 +104,8 @@ tasks.withType<ShadowJar> {
 
 tasks.withType<Wrapper> {
     gradleVersion = "7.1"
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/src/test/kotlin/no/nav/omsorgspengermidlertidigalene/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspengermidlertidigalene/ApplicationTest.kt
@@ -20,7 +20,6 @@ import no.nav.omsorgspengermidlertidigalene.wiremock.stubK9OppslagSoker
 import no.nav.omsorgspengermidlertidigalene.wiremock.stubOppslagHealth
 import org.json.JSONObject
 import org.junit.AfterClass
-import org.junit.BeforeClass
 import org.skyscreamer.jsonassert.JSONAssert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -72,13 +71,8 @@ class ApplicationTest {
 
         val engine = TestApplicationEngine(createTestEnvironment {
             config = getConfig(kafkaEnvironment)
-        })
-
-
-        @BeforeClass
-        @JvmStatic
-        fun buildUp() {
-            engine.start(wait = true)
+        }).apply {
+            start(wait = true)
         }
 
         @AfterClass


### PR DESCRIPTION
Konfigurerer tester til å kjøre på junit5 med org.jetbrains.kotlin:kotlin-test-junit5.
Starter engine direkte
* Closes #66 